### PR TITLE
feature: add shadow and border to code blocks on docs

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -7,7 +7,7 @@ type TMDXProps = ClassAttributes<HTMLPreElement> & HTMLAttributes<HTMLPreElement
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     pre: (props: TMDXProps) => (
-      <pre {...props} style={{ padding: 0 }} className='flex'>
+      <pre {...props} style={{ padding: 0, border: '2px solid #2E2F35', boxShadow: '3px 3px 0 0 #2E2F35' }} className='flex'>
         <div style={{ padding: '0.75rem', overflow: 'auto', width: '100%' }}>
           {props.children}
         </div>


### PR DESCRIPTION
## Evidences
<img width="821" alt="Screenshot 2024-04-04 at 16 35 23" src="https://github.com/agicommies/commune-page/assets/50849605/8302283b-5ce7-410c-9def-c083020f61c4">
